### PR TITLE
Configure escape char to fix import issues with escaped quotes

### DIFF
--- a/Python/data.py
+++ b/Python/data.py
@@ -20,7 +20,7 @@ def prepare_data(colmap, raw=None, data=None):
     # Read raw input into pandas DataFrame, if data
     # is not provided as such
     if data is None:
-        data = pd.read_csv(raw, sep=",", header=0)
+        data = pd.read_csv(raw, sep=",", header=0, escapechar='\\')
 
     # Get relevant keys from colmap
     key_c = colmap["key_c"]


### PR DESCRIPTION
Import of data.csv files failed on fields containing quotes with escaped double quotes, since [pandas.read_csv](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html) doesn't have a default escape char. 